### PR TITLE
Supress compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	 gcc example.c zlog.c -o example -lpthread
+	 gcc -Wall -Wextra example.c zlog.c -o example -lpthread
 	 ./example

--- a/zlog.c
+++ b/zlog.c
@@ -82,7 +82,7 @@ void zlog_init_stdout()
     zlog_fout = stdout;
 }
 
-void* zlog_buffer_flush_thread(void* arg)
+void* zlog_buffer_flush_thread()
 {
     struct timeval tv;
     time_t lasttime;


### PR DESCRIPTION
Added in Makefile -Wall -Wextra flags in order to see full gcc compilation messages. Modified zlog_buffer_flush_thread function from zlog.c since the parameter (void* arg) was not used. 