### PR TITLE
Zlog functionality check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	 gcc example.c zlog.c -o example -lpthread
+	 gcc -Wall -Wextra example.c zlog.c -o example -lpthread
 	 ./example

--- a/example.c
+++ b/example.c
@@ -43,14 +43,14 @@ int main(int argc, char* argv[])
     zlog_flush_buffer();
 
     // with source code file and line info, and timestamp
-    zlog_time(ZLOG_LOC, "more logs...\n");
+    zlog_time(ZLOG_LOC, "Log with file and line. TIMESTAMPED.\n");
 
     // with source code file and line info, and without timestamp
-    zlog(ZLOG_LOC, "and more logs...\n");
+    zlog(ZLOG_LOC, "Log with file and line. NO TIMESTAMP.\n");
 
     // Example only: let the flushing thread work
-    printf("FOR TEST: I will sleep for 600 seconds... Please be patient.\n");
-    sleep(600);
+    printf("FOR TEST: I will sleep for 10 seconds... Please be patient.\n");
+    sleep(10);
 
     zlogf_time("finish using zlog\n");
 

--- a/example.c
+++ b/example.c
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
 
     // Example only: let the flushing thread work
     printf("FOR TEST: I will sleep for 10 seconds... Please be patient.\n");
-    sleep(10);
+    sleep(200);
 
     zlogf_time("finish using zlog\n");
 

--- a/zlog.c
+++ b/zlog.c
@@ -82,7 +82,7 @@ void zlog_init_stdout()
     zlog_fout = stdout;
 }
 
-void* zlog_buffer_flush_thread(void* arg)
+void* zlog_buffer_flush_thread()
 {
     struct timeval tv;
     time_t lasttime;

--- a/zlog.c
+++ b/zlog.c
@@ -202,7 +202,7 @@ void zlog_time(char* filename, int line, char const * fmt, ...)
 #endif
 
     buffer = zlog_get_buffer();
-    snprintf(buffer, ZLOG_BUFFER_STR_MAX_LEN, "[%s.%06lds] [@%s:%d]", timebuf, tv.tv_usec, filename, line);
+    snprintf(buffer, ZLOG_BUFFER_STR_MAX_LEN, "[%s.%06lds] [@%s:%d] ", timebuf, tv.tv_usec, filename, line);
     buffer += strlen(buffer); // print at most 5 digit of line
 
     va_start(va, fmt);
@@ -221,7 +221,8 @@ void zlog(char* filename, int line, char const * fmt, ...)
     va_list va;
 
     buffer = zlog_get_buffer();
-    snprintf(buffer, ZLOG_BUFFER_STR_MAX_LEN, "[@%s:%d]", filename, line);
+    snprintf(buffer, ZLOG_BUFFER_STR_MAX_LEN, "[@%s:%d] ", filename, line);
+    buffer += strlen(buffer);
     va_start(va, fmt);
     vsnprintf(buffer, ZLOG_BUFFER_STR_MAX_LEN, fmt, va);
     zlog_finish_buffer();


### PR DESCRIPTION
Slightly modified zlog() function in log.c because it was not printing [@file, line] when called with ZLOG_LOC. Also modified example.c in order to clarify print messages. 