### PR TITLE
Quick fix for Meson build script.  Make static library only.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,7 @@ endif
 
 zlog_dir = include_directories('.')
 
-zlog_lib = library(meson.project_name(), 
+zlog_lib = static_library(meson.project_name(), 
     sources: ['zlog.c'],
     dependencies: thread_dep,
     include_directories: zlog_dir)

--- a/meson.build
+++ b/meson.build
@@ -12,8 +12,8 @@
 
 
 project('zlog', 'c',
+    license         : 'Unlicense',
     meson_version   : '>=0.50.0',
-    subproject_dir  : 'vendor',
     default_options : 
     [ 
         'werror=true',


### PR DESCRIPTION
Sorry to bother but I have quick fix.  This should allow proper linking with a static library.