### PR TITLE
Remove unneeded flush message

### DIFF
--- a/zlog.c
+++ b/zlog.c
@@ -120,7 +120,6 @@ static void* zlog_buffer_flush_thread()
             // the messages are at this point because, if they do
             // not meet message level requirement, that wouldn't
             // have been buffered in the first place.
-            zlogf_time(ZLOG_LOG_LEVEL, "Flush buffer.\n");
             zlog_flush_buffer();
             lasttime = curtime;
         } else {


### PR DESCRIPTION
This flush log adds unneeded noise into the logs